### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"
 quote = "1"
-sha2 = "0"
+sha2 = "0.10"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.